### PR TITLE
Refactor: send image path instead of base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,3 @@ Fix it using:
 ```
 
 #### On First Run,its not running well after the generation of the Keys. Please restart it.
-
-### Sending Images
-
-For sending Images,you will need to increase the maximum Job Size for beanstalkd.
- Add -z bytes to the
-On Ubuntu,edit the File //etc/default/beanstalkd
-add "-z <bytes>" to BEANSTALKD_EXTRA="" line.
-
-use a value like 2000000(2 megabytes)
-
-Credits go to:
-http://stackoverflow.com/questions/29199302/job-too-big-pheanstalk-what-can-be-done
-
-Warning: Currently big Images are not supported due to a Bug. I suppose that it has someting to do with the beanstalkd-client.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # yowsup-queue
-This Project provides a interface to yowsup2. You can Send/Receive Whatsapp-Messages with any language of your choice. 
+This Project provides a interface to yowsup2. You can Send/Receive Whatsapp-Messages with any language of your choice.
 
 ###Prerequisites:
 
-Install & Configure the yowsup2 CLI Demo. 
+Install & Configure the yowsup2 CLI Demo.
 
-Use yowsup-cli to register a Number. 
+Use yowsup-cli to register a Number.
 
 Install or use a Beanstalkd Server.
- 
+
 ###Installation(on Ubuntu):
 
 ```bash
@@ -29,7 +29,7 @@ rename "config.sample.ini" to "config.ini" and put your credentials into it.
 
 Run the Main Handler with:
 ```
-python3 run.py 
+python3 run.py
 ```
 
 You will get the Messages from Whatsapp into the Queue "whatsapp-receive".
@@ -38,7 +38,7 @@ Put the messages you want to send into the "whatsapp-send" Queue. The Format of 
 
 ### Integrations in other Languages/Software:
 
-PHP: 
+PHP:
 https://github.com/EliasKotlyar/yowsup-queue-php-api
 
 
@@ -54,13 +54,13 @@ Simple Message:
 Image Message:
 
 ```
-	{"type":"image","image":"<imagedata in base64>","address":"12345678"}
+	{"type":"image","image":"<local absolute image path>","address":"12345678"}
 ```
 
 
 ###Known Issues:
 
-#### Sometimes the keys are not synced. You will get Errors like this: 
+#### Sometimes the keys are not synced. You will get Errors like this:
 ```
 	Exception: No such signedprekeyrecord!
 ```
@@ -70,12 +70,12 @@ Fix it using:
 	(deleted the yowsup database)
 ```
 
-#### On First Run,its not running well after the generation of the Keys. Please restart it. 
+#### On First Run,its not running well after the generation of the Keys. Please restart it.
 
 ### Sending Images
 
 For sending Images,you will need to increase the maximum Job Size for beanstalkd.
- Add -z bytes to the 
+ Add -z bytes to the
 On Ubuntu,edit the File //etc/default/beanstalkd
 add "-z <bytes>" to BEANSTALKD_EXTRA="" line.
 
@@ -85,4 +85,3 @@ Credits go to:
 http://stackoverflow.com/questions/29199302/job-too-big-pheanstalk-what-can-be-done
 
 Warning: Currently big Images are not supported due to a Bug. I suppose that it has someting to do with the beanstalkd-client.
-

--- a/yowsupqueue/beanstalkstack.py
+++ b/yowsupqueue/beanstalkstack.py
@@ -64,10 +64,5 @@ class BeanstalkStack(threading.Thread):
         #self.output(number)
         self.yowsUpStack.broadcastEvent(YowLayerEvent(name=QueueLayer.EVENT_SEND_MESSAGE, msg=msg, number=number))
 
-    def sendImage(self, number, imgData):
-        data = base64.b64decode(imgData)
-        tf = tempfile.NamedTemporaryFile(prefix="yowsup-queue-tmp",suffix='.jpg',delete=False)
-        tf.write(data)
-        tf.close()
-        self.yowsUpStack.broadcastEvent(YowLayerEvent(name=QueueLayer.EVENT_SEND_IMAGE, path=tf.name, number=number))
-
+    def sendImage(self, number, imgPath):
+        self.yowsUpStack.broadcastEvent(YowLayerEvent(name=QueueLayer.EVENT_SEND_IMAGE, path=imgPath, number=number))


### PR DESCRIPTION
Hi, I have refactored the code.
I felt instead of sending base64 and then converting back to temp image, it is good that the user can send local absolute path of the image, which can be sent easily. This resolves the beanstalk larger image issue too. Please check.
